### PR TITLE
EAC-60504: Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,8 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v1.54.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: v1.54.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         go: [ '1.19.x', '1.20.x', '1.21.x']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go }}
       - run: go test -v ./...


### PR DESCRIPTION
https://veza.atlassian.net/browse/EAC-60504

## Summary
Original repo doesn't use pinning so we can't bring it in from them. Lint already fails on main.

- Pin all GitHub Actions in CI workflows to immutable SHA hashes to mitigate supply chain risk
- Bumps to latest stable versions: checkout v4, golangci-lint-action ~v7~ v6, setup-go v5

## Changes
| Workflow | Action | Before | After |
|----------|--------|--------|-------|
| lint.yml | actions/checkout | @v2 | @34e11487 (v4) |
| lint.yml | golangci/golangci-lint-action | @v3 | @9fae48ac (v7) |
| test.yml | actions/checkout | @v4 | @34e11487 (v4) |
| test.yml | actions/setup-go | @v4 | @40f1582b (v5) |

## Test plan
- [x] Verified SHA hashes resolve to correct tags via GitHub API